### PR TITLE
Improve workflow robustness and fix undefined variable

### DIFF
--- a/ai_analyzer.py
+++ b/ai_analyzer.py
@@ -41,7 +41,7 @@ def get_video_analysis(api_key, video_path, duration):
         print(f"An error occurred during AI analysis: {e}")
         return None
 
-def generate_creative_brief(api_key, product_info, analysis_data, duration):
+def generate_creative_brief(api_key, product_name, analysis_data, duration):
     """
     Generates the creative brief using the "Creative Director" prompt.
     """
@@ -51,10 +51,10 @@ def generate_creative_brief(api_key, product_info, analysis_data, duration):
         model = genai.GenerativeModel(model_name="models/gemini-1.5-pro-latest")
 
         timeline_analysis_str = json.dumps(analysis_data, indent=2)
-        
+
         prompt = CREATIVE_DIRECTOR_PROMPT.format(
             video_duration=duration,
-            product_info=product_info,
+            product_name=product_name,
             timeline_analysis=timeline_analysis_str
         )
         

--- a/app.py
+++ b/app.py
@@ -35,24 +35,38 @@ if st.button("Generate Brief", type="primary"):
                 # Full workflow execution
                 status.update(label="Step 1/5: Downloading video...")
                 video_path, duration = download_video(video_url)
+                if not video_path:
+                    raise RuntimeError("Video download failed.")
                 st.write(f"✅ Video downloaded ({duration:.2f}s).")
 
                 status.update(label="Step 2/5: Performing timeline analysis...")
                 analysis_data = get_video_analysis(gemini_api_key, video_path, duration)
+                if not analysis_data:
+                    raise RuntimeError("AI timeline analysis failed.")
                 st.write("✅ AI timeline analysis complete.")
 
                 status.update(label="Step 3/5: Extracting key moments...")
                 timestamps = [scene['screenshot_timestamp'] for scene in analysis_data.get('timeline', []) if 'screenshot_timestamp' in scene]
                 screenshot_paths = extract_screenshots(video_path, timestamps)
+                if not screenshot_paths:
+                    raise RuntimeError("No screenshots were extracted.")
                 st.write(f"✅ Extracted {len(screenshot_paths)} screenshots.")
 
                 status.update(label="Step 4/5: Generating creative brief...")
                 brief_json = generate_creative_brief(gemini_api_key, product_name, analysis_data, duration)
+                if not brief_json:
+                    raise RuntimeError("Creative brief generation failed.")
+
+                # Normalize shot type key naming
+                for shot in brief_json.get("shotList", []):
+                    if "shotType" in shot and "shot_type" not in shot:
+                        shot["shot_type"] = shot.pop("shotType")
+
                 st.write("✅ Creative brief written.")
 
                 status.update(label="Step 5/5: Assembling final PDF...")
                 pdf_path = "brief.pdf"
-                create_pdf_brief(product_info, brief_json, screenshot_paths, pdf_path)
+                create_pdf_brief(product_name, brief_json, screenshot_paths, pdf_path)
                 st.write("✅ PDF assembled.")
                 
                 # Store results for download button

--- a/document_generator.py
+++ b/document_generator.py
@@ -73,7 +73,7 @@ def create_pdf_brief(product_name, brief_json, screenshot_paths, output_path="br
             f"{shot.get('start_time', 0):.1f}s - {shot.get('end_time', 0):.1f}s",
             shot.get("action_description", ""),
             shot.get("dialogue_or_text", ""),
-            shot.get("shotType", "")
+            shot.get("shot_type") or shot.get("shotType", "")
         ]
         
         max_height = 0

--- a/prompts.py
+++ b/prompts.py
@@ -28,7 +28,7 @@ You are a world-class creative director. Your task is to take a detailed timelin
 The goal is to **mimic the timing, pacing, and style** of the reference video, but adapt the content for the new product.
 
 **Reference Video Total Duration:** {video_duration} seconds.
-**New Product to Feature:** {product_info}
+**New Product to Feature:** {product_name}
 
 **Provided Timeline Analysis (from reference video):**
 {timeline_analysis}
@@ -38,7 +38,7 @@ Generate a new, complete creative brief in a structured JSON format.
 Your entire output MUST be a valid JSON object with two top-level keys: "creativeConcept" and "shotList".
 
 1.  **"creativeConcept"**: A string containing a short, catchy concept for the new video.
-2.  **"shotList"**: An array of shot objects for the **new video**. For each object, you must:
+2.  **"shotList"**: An array of shot objects for the **new video**. Each object must include the keys `start_time`, `end_time`, `shot_type`, `action_description`, `dialogue_or_text`, and `editing_notes`. For each object, you must:
     * Re-use the `start_time` and `end_time` from the reference timeline to maintain the same pacing.
     * Re-use or adapt the `shot_type` and `editing_notes` to match the original style.
     * Write completely new `dialogue_or_text` and `action_description` that are relevant to the **new product**.


### PR DESCRIPTION
## Summary
- Add error handling to stop workflow when video download, AI analysis, screenshot extraction, or brief generation fails
- Fix undefined `product_info` variable by passing the user-provided `product_name` to the PDF generator
- Standardize naming to `product_name` throughout creative brief generation prompts and helper
- Normalize `shot_type` field so camera shot types appear in the final PDF brief

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b14420c3308323b4cc79a52edba299