### PR TITLE
Ensure temporary files are cleaned after processing

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 # app.py
 import streamlit as st
-from video_processor import download_video, extract_screenshots
+from video_processor import download_video, extract_screenshots, cleanup_temp_dir
 from ai_analyzer import get_video_analysis, generate_creative_brief
 from document_generator import create_pdf_brief
 
@@ -102,6 +102,8 @@ if st.button("Generate Brief", type="primary"):
             else:
                 st.session_state.run_complete = True  # Set to True only on full success
                 status.update(label="Workflow complete!", state="complete", expanded=False)
+            finally:
+                cleanup_temp_dir()
 
 if st.session_state.run_complete:
     st.header("Step 2: Download Your Brief")

--- a/video_processor.py
+++ b/video_processor.py
@@ -3,6 +3,7 @@ import os
 import yt_dlp
 import ffmpeg
 import sys
+import shutil
 
 TEMP_DIR = "temp"
 if not os.path.exists(TEMP_DIR):
@@ -62,3 +63,18 @@ def extract_screenshots(video_path, timestamps):
     
     print("Screenshot extraction complete.")
     return screenshot_paths
+
+
+def cleanup_temp_dir():
+    """Remove all files and folders inside the temporary directory."""
+    if not os.path.exists(TEMP_DIR):
+        return
+    for name in os.listdir(TEMP_DIR):
+        path = os.path.join(TEMP_DIR, name)
+        try:
+            if os.path.isfile(path) or os.path.islink(path):
+                os.unlink(path)
+            elif os.path.isdir(path):
+                shutil.rmtree(path)
+        except Exception as e:
+            print(f"Failed to delete {path}: {e}")


### PR DESCRIPTION
## Summary
- Implement `cleanup_temp_dir` to remove all files from the temp workspace.
- Import and invoke cleanup in `app.py` so the temp directory is cleared after PDF generation regardless of success.

## Testing
- `python -m py_compile app.py video_processor.py`


------
https://chatgpt.com/codex/tasks/task_e_68b15f8f3ab483239113c92b756fae1f