### PR TITLE
Support product page scraping for product fact research

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,6 @@ ffmpeg-python
 google-generativeai
 pillow
 fpdf2
+requests
+beautifulsoup4
 

--- a/web_utils.py
+++ b/web_utils.py
@@ -1,0 +1,25 @@
+"""Utility functions for web interactions."""
+
+from __future__ import annotations
+
+import requests
+from bs4 import BeautifulSoup
+
+
+def fetch_product_page_text(url: str) -> str:
+    """Fetch a URL and return visible text content.
+
+    The HTML is fetched via ``requests`` and parsed with ``BeautifulSoup``.
+    Script and style tags are removed before extracting text. Whitespace is
+    normalized and empty lines are stripped.
+    """
+
+    resp = requests.get(url, timeout=10)
+    resp.raise_for_status()
+
+    soup = BeautifulSoup(resp.text, "html.parser")
+    for tag in soup(["script", "style", "noscript"]):
+        tag.decompose()
+    text = soup.get_text(separator="\n")
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary
- Add product page URL input and debug view in Target Product Facts
- Implement `fetch_product_page_text` using requests and BeautifulSoup
- Extend product research prompts to include scraped page text

## Testing
- `python -m py_compile app.py prompts.py web_utils.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b64dcc179083238ba8043a0b3750f1