### PR TITLE
Warn when product facts missing

### DIFF
--- a/app.py
+++ b/app.py
@@ -216,12 +216,18 @@ if st.button("🔍 Research product facts"):
             try:
                 data = json.loads(research_json)
                 st.session_state["product_research"] = data
-                st.session_state["claims_text"] = "\n".join(data.get("approved_claims", []))
-                st.session_state["forbidden_text"] = "\n".join(data.get("forbidden", []))
-                st.session_state["disclaimers_text"] = "\n".join(
-                    data.get("required_disclaimers", [])
-                )
-                st.info("Review and verify the claims below before proceeding.")
+                approved_claims_list = data.get("approved_claims", []) or []
+                forbidden_list = data.get("forbidden", []) or []
+                disclaimers_list = data.get("required_disclaimers", []) or []
+
+                st.session_state["claims_text"] = "\n".join(approved_claims_list)
+                st.session_state["forbidden_text"] = "\n".join(forbidden_list)
+                st.session_state["disclaimers_text"] = "\n".join(disclaimers_list)
+
+                if approved_claims_list or forbidden_list or disclaimers_list:
+                    st.info("Review and verify the claims below before proceeding.")
+                else:
+                    st.warning("No product facts found; verify the URL or enter claims manually.")
             except Exception:
                 st.error("Research returned invalid JSON")
         except EmptyGeminiResponseError:

--- a/prompts.py
+++ b/prompts.py
@@ -169,9 +169,9 @@ SCRIPT_JSON_SCHEMA = dedent("""
 
 
 ANALYZER_SYSTEM_PREAMBLE = dedent("""
-You are a Film Director + Editor + Script Supervisor analyzing a short-form video to produce a director-ready breakdown. 
-Think step-by-step, but OUTPUT MUST BE JSON ONLY and must match the provided schema exactly. 
-If you cannot verify a field, set a safe default or null. Do not invent on-screen text.
+You are a Film Director + Editor + Script Supervisor dissecting a short-form video into a director-ready breakdown.
+Think step-by-step and capture the creator's style, but OUTPUT MUST BE JSON ONLY and match the provided schema exactly.
+If you cannot verify a field, set a safe default or null. Never invent on-screen text.
 """).strip()
 
 ANALYZER_USER_INSTRUCTIONS = dedent(f"""
@@ -180,12 +180,12 @@ Return ONLY valid JSON adhering to this schema:
 {ANALYZER_JSON_SCHEMA}
 
 Rules:
-1) Do NOT hallucinate on-screen text. If unknown, use [] for "on_screen_text" in that scene.
-2) Every scene must include: start_s, end_s, shot, camera, framing, action, dialogue_vo (or ""), music_moment, transition_out, retention_device.
-3) Populate influencer_DNA from delivery evidence: persona_tags, energy_1to5, pace, rhetoric, eye_contact_pct.
-4) Create a "beats" array marking hooks, emphatic punches, reveals, and CTA entries by timestamp.
-5) Note compliance risks in "compliance.forbidden_claims".
-6) Durations must be consistent; last scene end_s equals video duration.
+1) Provide accurate video_metadata.duration_s and ensure the last scene's end_s equals this duration.
+2) Every scene is a shooting-script entry: include start_s, end_s, shot, lens_feel, camera, framing, location, lighting, action, dialogue_vo (or ""), on_screen_text, sfx, music_moment, transition_out, retention_device, product_focus, disclaimer.
+3) Populate influencer_DNA from delivery evidence: persona_tags, energy_1to5, pace, sentiment_arc, delivery (POV, eye_contact_pct, gesture_style, rhetoric), and editing_style (cuts, text_style, anim, color_grade).
+4) Create a beats array marking hooks, emphatic punches, reveals, and CTA entries by timestamp.
+5) Note compliance risks in compliance.forbidden_claims and required_disclaimers.
+6) Flag reusable techniques in transferable_patterns.must_keep and call out non-transferable elements in transferable_patterns.rewrite.
 7) OUTPUT JSON ONLY. No markdown. No commentary.
 """).strip()
 


### PR DESCRIPTION
## Summary
- warn when product research returns no claims, disclaimers, or forbidden info
- refine reference-video analyzer prompts to capture influencer DNA, shooting details, and timing

## Testing
- `python -m py_compile app.py prompts.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b64e9600fc832394672cb335f46e32