### PR TITLE
Warn when product facts missing: handle string timestamps for reference stills

### DIFF
--- a/app.py
+++ b/app.py
@@ -401,7 +401,12 @@ with col_out_a:
         if stills:
             st.subheader("Reference Stills")
             for s in stills:
-                caption = f"{s.get('t',0):.2f}s — {s.get('label','')}"
+                t = s.get("t", 0)
+                try:
+                    t = float(t)
+                except Exception:
+                    t = 0.0
+                caption = f"{t:.2f}s — {s.get('label','')}"
                 path = s.get("frame_path")
                 if path and os.path.exists(path):
                     st.image(path, caption=caption)


### PR DESCRIPTION
## Summary
- convert key-frame timestamp to float before formatting to avoid Streamlit crash

## Testing
- `python -m py_compile app.py prompts.py document_generator.py video_processor.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6664a33b08323930604b771700020