### PR TITLE
Add orientation and responsive table rendering

### DIFF
--- a/app.py
+++ b/app.py
@@ -410,11 +410,23 @@ if st.session_state["analyzer_json_str"] and st.session_state["script_json_str"]
         product_facts=product_facts,
         title="AI-Generated Influencer Brief (Director Mode)",
     )
+    orientation_choice = st.selectbox(
+        "PDF orientation",
+        ["Auto", "Portrait", "Landscape"],
+        index=0,
+    )
+    orientation_arg = None
+    if orientation_choice == "Portrait":
+        orientation_arg = "P"
+    elif orientation_choice == "Landscape":
+        orientation_arg = "L"
+
     pdf_bytes = make_brief_pdf(
         analyzer=st.session_state["analyzer_parsed"],
         script=st.session_state["script_parsed"],
         product_facts=product_facts,
         title="AI-Generated Influencer Brief (Director Mode)",
+        orientation=orientation_arg,
     )
     st.download_button(
         "⬇️ Download brief.md",


### PR DESCRIPTION
## Summary
- allow `make_brief_pdf` callers to choose portrait or landscape orientation and auto-switch for wide tables
- compute table column widths from page width and shrink/rotate headers when space is tight
- expose orientation selection in the Streamlit export UI

## Testing
- `python -m py_compile document_generator.py app.py`
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b66d5948f88323a561311b9d956640