### PR TITLE
feat: configure Gemini output token limit

### DIFF
--- a/app.py
+++ b/app.py
@@ -92,6 +92,7 @@ def call_gemini_json(
     temperature: float = 0.2,
     max_retries: int = 3,
     retry_base: float = 1.5,
+    max_output_tokens: int = 4096,
 ) -> str:
     """Calls Gemini and returns a JSON string (we request application/json)."""
     _ensure_gemini_configured()
@@ -102,7 +103,11 @@ def call_gemini_json(
             mdl = genai.GenerativeModel(model)
             resp = mdl.generate_content(
                 prompt_text,
-                generation_config={"temperature": temperature, "response_mime_type": "application/json"},
+                generation_config={
+                    "temperature": temperature,
+                    "response_mime_type": "application/json",
+                    "max_output_tokens": max_output_tokens,
+                },
             )
             if not resp.text:
                 raise EmptyGeminiResponseError("Gemini returned no text")


### PR DESCRIPTION
## Summary
- allow passing `max_output_tokens` to Gemini calls
- default to 4096 output tokens for more robust JSON responses

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b678ac72848323b121b1b48d99d134