### PR TITLE
Refactor PDF brief to separate summary and storyboard pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -425,7 +425,7 @@ if st.session_state["analyzer_json_str"] and st.session_state["script_json_str"]
         title="AI-Generated Influencer Brief (Director Mode)",
     )
     orientation_choice = st.selectbox(
-        "PDF orientation",
+        "Storyboard page orientation",
         ["Auto", "Portrait", "Landscape"],
         index=0,
     )
@@ -449,7 +449,7 @@ if st.session_state["analyzer_json_str"] and st.session_state["script_json_str"]
         mime="text/markdown",
     )
     st.download_button(
-        "⬇️ Download brief.pdf",
+        "⬇️ Download brief (summary + storyboard).pdf",
         data=pdf_bytes,
         file_name="brief.pdf",
         mime="application/pdf",


### PR DESCRIPTION
## Summary
- Generate PDF briefs with a summary on page one and the storyboard table on page two
- Provide orientation control for the storyboard page and clarify download label

## Testing
- `python -m pytest`
- `python -m py_compile document_generator.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b68508564083238d4410a1463a6a0b