### PR TITLE
Improve PDF text wrapping

### DIFF
--- a/document_generator.py
+++ b/document_generator.py
@@ -199,24 +199,21 @@ def make_brief_pdf(
             pdf.ln(PARA_SPACING)
             i += 1
             continue
-        try:
-            if line.startswith("# "):
-                pdf.set_font("DejaVu", size=16)
-                pdf.multi_cell(0, 8, line[2:].strip())
-                pdf.set_font("DejaVu", size=12)
-            elif line.startswith("## "):
-                pdf.set_font("DejaVu", size=14)
-                pdf.multi_cell(0, 7, line[3:].strip())
-                pdf.set_font("DejaVu", size=12)
-            elif line.startswith("### "):
-                pdf.set_font("DejaVu", size=12)
-                pdf.multi_cell(0, 6, line[4:].strip())
-            elif line.startswith("- "):
-                _render_list_item(pdf, line[2:].strip())
-            else:
-                pdf.multi_cell(0, 6, line)
-        except FPDFException:
-            pdf.cell(0, 6, line, ln=1)
+        if line.startswith("# "):
+            pdf.set_font("DejaVu", size=16)
+            pdf.multi_cell(pdf.epw, 8, line[2:].strip())
+            pdf.set_font("DejaVu", size=12)
+        elif line.startswith("## "):
+            pdf.set_font("DejaVu", size=14)
+            pdf.multi_cell(pdf.epw, 7, line[3:].strip())
+            pdf.set_font("DejaVu", size=12)
+        elif line.startswith("### "):
+            pdf.set_font("DejaVu", size=12)
+            pdf.multi_cell(pdf.epw, 6, line[4:].strip())
+        elif line.startswith("- "):
+            _render_list_item(pdf, line[2:].strip())
+        else:
+            pdf.multi_cell(pdf.epw, 6, line)
         i += 1
 
     # ---- Render storyboard page ----
@@ -241,24 +238,21 @@ def make_brief_pdf(
             pdf.ln(PARA_SPACING)
             i += 1
             continue
-        try:
-            if line.startswith("# "):
-                pdf.set_font("DejaVu", size=16)
-                pdf.multi_cell(0, 8, line[2:].strip())
-                pdf.set_font("DejaVu", size=12)
-            elif line.startswith("## "):
-                pdf.set_font("DejaVu", size=14)
-                pdf.multi_cell(0, 7, line[3:].strip())
-                pdf.set_font("DejaVu", size=12)
-            elif line.startswith("### "):
-                pdf.set_font("DejaVu", size=12)
-                pdf.multi_cell(0, 6, line[4:].strip())
-            elif line.startswith("- "):
-                _render_list_item(pdf, line[2:].strip())
-            else:
-                pdf.multi_cell(0, 6, line)
-        except FPDFException:
-            pdf.cell(0, 6, line, ln=1)
+        if line.startswith("# "):
+            pdf.set_font("DejaVu", size=16)
+            pdf.multi_cell(pdf.epw, 8, line[2:].strip())
+            pdf.set_font("DejaVu", size=12)
+        elif line.startswith("## "):
+            pdf.set_font("DejaVu", size=14)
+            pdf.multi_cell(pdf.epw, 7, line[3:].strip())
+            pdf.set_font("DejaVu", size=12)
+        elif line.startswith("### "):
+            pdf.set_font("DejaVu", size=12)
+            pdf.multi_cell(pdf.epw, 6, line[4:].strip())
+        elif line.startswith("- "):
+            _render_list_item(pdf, line[2:].strip())
+        else:
+            pdf.multi_cell(pdf.epw, 6, line)
         i += 1
 
     pdf_bytes = pdf.output(dest="S")
@@ -445,27 +439,8 @@ def _render_list_item(pdf: FPDF, text: str, bullet: str = "-") -> None:
     epw = getattr(pdf, "epw", pdf.w - 2 * pdf.l_margin)
     max_width = epw - indent
 
-    start_x = pdf.get_x()
-    start_y = pdf.get_y()
-
-    try:
-        lines = pdf.multi_cell(max_width, line_height, text, split_only=True)
-    except FPDFException:
-        pdf.set_xy(start_x, start_y)
-        pdf.cell(0, line_height, f"{bullet_str}{text}", ln=1)
-        return
-
-    if start_y + line_height * len(lines) > pdf.page_break_trigger:
-        pdf.add_page()
-        start_x = pdf.get_x()
-        start_y = pdf.get_y()
-
-    pdf.set_xy(start_x, start_y)
     pdf.cell(indent, line_height, bullet_str)
-    pdf.cell(max_width, line_height, lines[0], ln=1)
-    for line in lines[1:]:
-        pdf.set_x(pdf.l_margin + indent)
-        pdf.cell(max_width, line_height, line, ln=1)
+    pdf.multi_cell(max_width, line_height, text)
 
 
 # =========================


### PR DESCRIPTION
## Summary
- Pre-wrap each summary and storyboard line with `pdf.multi_cell(pdf.epw, ...)` and remove fallback to `pdf.cell()`
- Render list items using `pdf.multi_cell` for automatic wrapping instead of manual splitting

## Testing
- `python -m py_compile document_generator.py`
- `python - <<'PY'
from document_generator import make_brief_pdf
analyzer = {'video_metadata': {}, 'global_style': {}, 'beats_table': [], 'scenes_table': []}
script = {'opening': [], 'scenes_table': [], 'cta_options': [], 'checklist': []}
long_line = 'This is a very long line ' * 20
product_facts = {'approved_claims': [long_line]}
pdf_bytes = make_brief_pdf(analyzer=analyzer, script=script, product_facts=product_facts)
print('PDF bytes', len(pdf_bytes))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b68a642ab083239fdefc9899a8ef91