### PR TITLE
Preserve multi-cell column position

### DIFF
--- a/document_generator.py
+++ b/document_generator.py
@@ -299,8 +299,11 @@ def _safe_multi_cell(
     """Render text using ``multi_cell`` with manual wrapping fallback."""
 
     lines = _wrap_text(pdf, width, text)
-    for line in lines:
+    start_x = pdf.get_x()
+    for i, line in enumerate(lines):
         pdf.multi_cell(width, line_height, line, **kwargs)
+        if i < len(lines) - 1:
+            pdf.set_x(start_x)
 
 def _split_row_cells(
     pdf: FPDF, cells: List[Any], col_widths: List[float], line_height: float


### PR DESCRIPTION
## Summary
- keep starting x position when rendering wrapped text via `_safe_multi_cell`
- reset x for subsequent lines to preserve column alignment

## Testing
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6936f4c388323906961897e6fc119