### PR TITLE
Ensure DejaVu bold style fallback and en dash regression test

### DIFF
--- a/tests/test_en_dash_pdf.py
+++ b/tests/test_en_dash_pdf.py
@@ -1,0 +1,31 @@
+import io
+from pathlib import Path
+import sys
+
+from pdfminer.high_level import extract_text
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from document_generator import make_brief_pdf
+
+
+def test_make_brief_pdf_handles_en_dash():
+    analyzer = {
+        "scenes": [
+            {
+                "start_s": 0,
+                "end_s": 1,
+                "shot_type": "",
+                "framing": "",
+                "action": "",
+                "dialogue": "",
+                "on_screen_text": "",
+                "screenshot_path": "",
+            }
+        ]
+    }
+
+    pdf_bytes = make_brief_pdf(analyzer=analyzer, script={}, product_facts={})
+
+    text = extract_text(io.BytesIO(pdf_bytes))
+
+    assert "0.00–1.00" in text


### PR DESCRIPTION
## Summary
- Register a DejaVu `B` style alias when the bold TTF file is missing so bold can be selected without changing font families
- Keep table rendering on the current font family, using bold style only when available and restoring the original font
- Add a regression test ensuring PDFs with en dashes render without `FPDFUnicodeEncodingException`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6aad00eb883239b3e623232bee0fd