### PR TITLE
Ensure padding applied once when wrapping PDF text

### DIFF
--- a/document_generator.py
+++ b/document_generator.py
@@ -313,7 +313,15 @@ def _parse_table_block(
     return header, rows, i
 
 def _wrap_text(pdf: FPDF, width: float, text: str) -> List[str]:
-    width = max(width - PADDING, 0)
+    """Split *text* into lines that fit within *width*.
+
+    The caller is responsible for accounting for any desired padding so that
+    both wrapping and rendering use the same effective width.  This helper only
+    guards against negative widths to avoid errors from FPDF.
+    """
+
+    # Avoid negative widths which can cause FPDF to raise exceptions
+    width = max(width, 0)
     try:
         x, y = pdf.get_x(), pdf.get_y()
         lines = pdf.multi_cell(width, 1, text, border=0, split_only=True)
@@ -367,7 +375,8 @@ def _split_row_cells(
             max_lines = max(max_lines, math.ceil(_IMAGE_CELL_HEIGHT / line_height))
         else:
             text = "" if cell is None else str(cell)
-            lines = _wrap_text(pdf, cw - CELL_PADDING, text)
+            available_width = max(cw - CELL_PADDING, 0)
+            lines = _wrap_text(pdf, available_width, text)
             cell_lines.append(lines)
             max_lines = max(max_lines, len(lines))
     return cell_lines, line_height * max_lines

--- a/tests/test_pdf_wrapping.py
+++ b/tests/test_pdf_wrapping.py
@@ -20,11 +20,17 @@ def _iter_text_lines(layout_obj):
             yield from _iter_text_lines(child)
 
 
-def assert_pdf_lines_fit(page_iter):
+def assert_pdf_lines_fit(page_iter, pdf):
+    """Assert that rendered text lines stay within the page margins."""
+
+    l_margin_pt = pdf.l_margin * pdf.k
+    r_margin_pt = pdf.r_margin * pdf.k
+
     for page in page_iter:
         width = page.width
         for line in _iter_text_lines(page):
-            assert line.x1 <= width + 1  # allow tiny rounding tolerance
+            assert line.x0 >= l_margin_pt - 1
+            assert line.x1 <= width - r_margin_pt + 1
 
 
 def test_long_unbroken_word_and_bullet_list():
@@ -45,7 +51,7 @@ def test_long_unbroken_word_and_bullet_list():
     _render_list_item(pdf, long_word)
 
     pdf_bytes = bytes(pdf.output(dest="S"))
-    assert_pdf_lines_fit(extract_pages(io.BytesIO(pdf_bytes)))
+    assert_pdf_lines_fit(extract_pages(io.BytesIO(pdf_bytes)), pdf)
 
 
 def test_narrow_table_columns_wrap():
@@ -64,4 +70,4 @@ def test_narrow_table_columns_wrap():
     _render_table(pdf, headers, rows)
 
     pdf_bytes = bytes(pdf.output(dest="S"))
-    assert_pdf_lines_fit(extract_pages(io.BytesIO(pdf_bytes)))
+    assert_pdf_lines_fit(extract_pages(io.BytesIO(pdf_bytes)), pdf)


### PR DESCRIPTION
## Summary
- Prevent `_wrap_text` from subtracting padding so callers handle it once and rendering uses the same width as wrapping.
- Pass explicit column widths when splitting table rows to match the new wrapping logic.
- Expand PDF layout tests to verify text respects left and right margins.

## Testing
- `pytest -q --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68b6ac0dc5e48323a4a149ede520a8b5