### PR TITLE
fix: restore x for multiline pdf cells

### DIFF
--- a/document_generator.py
+++ b/document_generator.py
@@ -410,6 +410,8 @@ def _render_table_row(
             pdf.set_xy(x + CELL_PADDING / 2, y_top + 1)
             for li, l in enumerate(cell):
                 pdf.multi_cell(cw - CELL_PADDING, line_height, l)
+                if li < len(cell) - 1:
+                    pdf.set_x(x + CELL_PADDING / 2)
         x += cw
 
     pdf.set_xy(start_x, y_top + row_height)


### PR DESCRIPTION
## Summary
- ensure table rows reset x after multi-cell text to keep wrapped lines within cell borders

## Testing
- `pytest -q`
- `python - <<'PY'
from fpdf import FPDF
from document_generator import _render_table

pdf = FPDF()
pdf.add_page()
pdf.set_font('Helvetica', size=12)
headers = ['Col1', 'Col2']
rows = [['This is a long text that should wrap within the cell boundary and continue to next line', 'Short']]
_render_table(pdf, headers, rows)
pdf.output('test.pdf')
print('generated test.pdf')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b7a381b0f883239b457c4397e44f4d